### PR TITLE
Group projects by status

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -8,10 +8,16 @@ class ProjectController extends Controller
 {
     public function index()
     {
+        [$behind, $current] = Project::valid()->active()->get()->sortBy(function ($project) {
+            return strtolower($project->name);
+        })->partition(function ($project) {
+            return $project->is_behind_latest;
+        });
+
         return view('welcome', [
-            'projects' => Project::valid()->active()->get()->sortBy(function ($project) {
-                return strtolower($project->name);
-            }),
+            'count' => $behind->count() + $current->count(),
+            'behind' => $behind,
+            'current' => $current,
         ]);
     }
 }

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -22,36 +22,6 @@
             </ul>
 
             <section class="bg-white rounded-b-lg">
-                @foreach ($current as $project)
-                    <ul class="flex list-reset p-4 border-t border-smoke">
-                        <li class="w-2/6">
-                            <a class="text-indigo-700 hover:text-indigo-900 no-underline text-md" href="{{ $project->github_url }}">
-                                {{ $project->name }}
-                            </a>
-                        </li>
-
-                        <li class="w-1/6 text-black-lightest">{{ $project->current_laravel_constraint }}</li>
-
-                        <li class="w-1/6 text-black-lightest">{{ $project->current_laravel_version }}</li>
-
-                        <li class="w-1/6 text-black-lightest">{{ $project->desired_laravel_version }}</li>
-
-                        <li class="w-1/6 text-black-lightest">
-                            <span class="text-green-700">CURRENT</span>
-                        </li>
-
-                        <li class="w-1/6">
-                            <form action="{{ route('project.ignore', $project) }}" method="POST">
-                                @method('PATCH')
-                                @csrf
-                                <input type="submit" value="Ignore" class="bg-indigo-600 hover:bg-indigo-500 text-white px-3 py-1 rounded cursor-pointer">
-                            </form>
-                        </li>
-                    </ul>
-                @endforeach
-            </section>
-
-            <section class="bg-white rounded-b-lg">
                 @foreach ($behind as $project)
                     <ul class="flex list-reset p-4 border-t border-smoke">
                         <li class="w-2/6">
@@ -81,6 +51,35 @@
                 @endforeach
             </section>
 
+            <section class="bg-white rounded-b-lg">
+                @foreach ($current as $project)
+                    <ul class="flex list-reset p-4 border-t border-smoke">
+                        <li class="w-2/6">
+                            <a class="text-indigo-700 hover:text-indigo-900 no-underline text-md" href="{{ $project->github_url }}">
+                                {{ $project->name }}
+                            </a>
+                        </li>
+
+                        <li class="w-1/6 text-black-lightest">{{ $project->current_laravel_constraint }}</li>
+
+                        <li class="w-1/6 text-black-lightest">{{ $project->current_laravel_version }}</li>
+
+                        <li class="w-1/6 text-black-lightest">{{ $project->desired_laravel_version }}</li>
+
+                        <li class="w-1/6 text-black-lightest">
+                            <span class="text-green-700">CURRENT</span>
+                        </li>
+
+                        <li class="w-1/6">
+                            <form action="{{ route('project.ignore', $project) }}" method="POST">
+                                @method('PATCH')
+                                @csrf
+                                <input type="submit" value="Ignore" class="bg-indigo-600 hover:bg-indigo-500 text-white px-3 py-1 rounded cursor-pointer">
+                            </form>
+                        </li>
+                    </ul>
+                @endforeach
+            </section>
         </div>
     </div>
     <br><br>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,7 +4,7 @@
 <div class="bg-gray-100 font-sans relative z-0">
     <div class="max-w-6xl mx-auto pt-8">
         <p class="mb-6 text-black-lighter">
-            Showing versions for {{ $projects->count() }} active projects and packages
+            Showing versions for {{ $count }} active projects and packages
         </p>
         <div class="rounded-lg shadow">
             <ul class="bg-gray-400 flex list-reset p-4 rounded-t-lg border-gray border-b-2">
@@ -22,7 +22,7 @@
             </ul>
 
             <section class="bg-white rounded-b-lg">
-                @foreach ($projects as $project)
+                @foreach ($current as $project)
                     <ul class="flex list-reset p-4 border-t border-smoke">
                         <li class="w-2/6">
                             <a class="text-indigo-700 hover:text-indigo-900 no-underline text-md" href="{{ $project->github_url }}">
@@ -37,11 +37,7 @@
                         <li class="w-1/6 text-black-lightest">{{ $project->desired_laravel_version }}</li>
 
                         <li class="w-1/6 text-black-lightest">
-                            @if ($project->is_behind_latest)
-                                <span class="font-bold text-red-700">BEHIND</span>
-                            @else
-                                <span class="text-green-700">CURRENT</span>
-                            @endif
+                            <span class="text-green-700">CURRENT</span>
                         </li>
 
                         <li class="w-1/6">
@@ -54,6 +50,37 @@
                     </ul>
                 @endforeach
             </section>
+
+            <section class="bg-white rounded-b-lg">
+                @foreach ($behind as $project)
+                    <ul class="flex list-reset p-4 border-t border-smoke">
+                        <li class="w-2/6">
+                            <a class="text-indigo-700 hover:text-indigo-900 no-underline text-md" href="{{ $project->github_url }}">
+                                {{ $project->name }}
+                            </a>
+                        </li>
+
+                        <li class="w-1/6 text-black-lightest">{{ $project->current_laravel_constraint }}</li>
+
+                        <li class="w-1/6 text-black-lightest">{{ $project->current_laravel_version }}</li>
+
+                        <li class="w-1/6 text-black-lightest">{{ $project->desired_laravel_version }}</li>
+
+                        <li class="w-1/6 text-black-lightest">
+                            <span class="font-bold text-red-700">BEHIND</span>
+                        </li>
+
+                        <li class="w-1/6">
+                            <form action="{{ route('project.ignore', $project) }}" method="POST">
+                                @method('PATCH')
+                                @csrf
+                                <input type="submit" value="Ignore" class="bg-indigo-600 hover:bg-indigo-500 text-white px-3 py-1 rounded cursor-pointer">
+                            </form>
+                        </li>
+                    </ul>
+                @endforeach
+            </section>
+
         </div>
     </div>
     <br><br>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -23,7 +23,7 @@
 
             <section class="bg-white rounded-b-lg">
                 @foreach ($behind as $project)
-                    <ul class="flex list-reset p-4 border-t border-smoke">
+                    <ul class="flex list-reset p-4 border-t border-smoke bg-red-100">
                         <li class="w-2/6">
                             <a class="text-indigo-700 hover:text-indigo-900 no-underline text-md" href="{{ $project->github_url }}">
                                 {{ $project->name }}
@@ -53,7 +53,7 @@
 
             <section class="bg-white rounded-b-lg">
                 @foreach ($current as $project)
-                    <ul class="flex list-reset p-4 border-t border-smoke">
+                    <ul class="flex list-reset p-4 border-t border-smoke bg-green-100">
                         <li class="w-2/6">
                             <a class="text-indigo-700 hover:text-indigo-900 no-underline text-md" href="{{ $project->github_url }}">
                                 {{ $project->name }}


### PR DESCRIPTION
This PR groups projects by their status:
![checkmate](https://user-images.githubusercontent.com/1141514/94317446-34ab0d00-ff3b-11ea-90f1-2364e992716a.png)

---

@mattstauffer I kind of want to make the projects stand out a bit more...is this too excessive? If not I'll commit that change.
![checkmate test_2](https://user-images.githubusercontent.com/1141514/94317747-c286f800-ff3b-11ea-848d-f16be20c6815.png)

---

Closes #25 