### PR TITLE
Add insecure status

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -9,11 +9,17 @@ class ProjectController extends Controller
     public function index()
     {
         $projects = Project::valid()->active()->get()->sortBy(function ($project) {
-            return $project->status;
+            // 1st Insecure | 2nd Behind | 3rd Current
+            if ($project->status === Project::STATUS_INSECURE) {
+                return 1;
+            }
+            if ($project->status === Project::STATUS_BEHIND) {
+                return 2;
+            }
+            return 3;
         });
 
         return view('welcome', [
-            'count' => $projects->count(),
             'projects' => $projects,
         ]);
     }

--- a/app/Project.php
+++ b/app/Project.php
@@ -60,7 +60,7 @@ class Project extends Model
 
     public function getStatusAttribute()
     {
-        if (!$this->is_behind_latest) {
+        if (! $this->is_behind_latest) {
             return self::STATUS_CURRENT;
         }
 
@@ -69,16 +69,18 @@ class Project extends Model
 
     private function hasSecurityFixes()
     {
-        $major= explode('.', $this->current_laravel_version)[0];
+        $major = explode('.', $this->current_laravel_version)[0];
 
         if ($major === '8') {
             // @see https://laravel.com/docs/8.x/releases#support-policy
             return strtotime('September 8th, 2021') >= strtotime('today');
         }
+
         if ($major === '7') {
             // @see https://laravel.com/docs/7.x/releases#support-policy
             return strtotime('March 3rd, 2021') >= strtotime('today');
         }
+
         if ($major === '6') {
             // @see https://laravel.com/docs/6.x/releases#support-policy
             return strtotime('September 3rd, 2022') >= strtotime('today');

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -3,22 +3,3 @@
 @tailwind components;
 
 @tailwind utilities;
-
-.status-insecure  {
-    --text-opacity: 1;
-    color: #c53030;
-    color: rgba(197, 48, 48, var(--text-opacity));
-    font-weight: 700;
-}
-
-.status-behind {
-    --text-opacity: 1;
-    color: #c53030;
-    color: rgba(197, 48, 48, var(--text-opacity));
-}
-
-.status-current {
-    --text-opacity: 1;
-    color: #2f855a;
-    color: rgba(47, 133, 90, var(--text-opacity));
-}

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -3,3 +3,22 @@
 @tailwind components;
 
 @tailwind utilities;
+
+.status-insecure  {
+    --text-opacity: 1;
+    color: #c53030;
+    color: rgba(197, 48, 48, var(--text-opacity));
+    font-weight: 700;
+}
+
+.status-behind {
+    --text-opacity: 1;
+    color: #c53030;
+    color: rgba(197, 48, 48, var(--text-opacity));
+}
+
+.status-current {
+    --text-opacity: 1;
+    color: #2f855a;
+    color: rgba(47, 133, 90, var(--text-opacity));
+}

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -37,11 +37,7 @@
                         <li class="w-1/6 text-black-lightest">{{ $project->desired_laravel_version }}</li>
 
                         <li class="w-1/6 text-black-lightest">
-                            @if ($project->is_behind_latest)
-                                <span class="font-bold text-red-700">BEHIND</span>
-                            @else
-                                <span class="text-green-700">CURRENT</span>
-                            @endif
+                            <span class="status-{{ $project->status }}">{{ strtoupper($project->status) }}</span>
                         </li>
 
                         <li class="w-1/6">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,3 +1,10 @@
+<?php
+$colorByStatus = [
+    App\Project::STATUS_CURRENT => 'text-green-400',
+    App\Project::STATUS_BEHIND => 'text-red-700',
+    App\Project::STATUS_INSECURE => 'text-red-700 font-bold',
+]
+?>
 @extends('layouts.app')
 
 @section('content')
@@ -23,7 +30,7 @@
 
             <section class="bg-white rounded-b-lg">
                 @foreach ($projects as $project)
-                    <ul class="flex list-reset p-4 border-t border-smoke bg-red-100">
+                    <ul class="flex list-reset p-4 border-t border-smoke">
                         <li class="w-2/6">
                             <a class="text-indigo-700 hover:text-indigo-900 no-underline text-md" href="{{ $project->github_url }}">
                                 {{ $project->name }}
@@ -37,7 +44,7 @@
                         <li class="w-1/6 text-black-lightest">{{ $project->desired_laravel_version }}</li>
 
                         <li class="w-1/6 text-black-lightest">
-                            <span class="status-{{ $project->status }}">{{ strtoupper($project->status) }}</span>
+                            <span class="{{ $colorByStatus[$project->status] }}">{{ strtoupper($project->status) }}</span>
                         </li>
 
                         <li class="w-1/6">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,7 +4,7 @@
 <div class="bg-gray-100 font-sans relative z-0">
     <div class="max-w-6xl mx-auto pt-8">
         <p class="mb-6 text-black-lighter">
-            Showing versions for {{ $count }} active projects and packages
+            Showing versions for {{ $projects->count() }} active projects and packages
         </p>
         <div class="rounded-lg shadow">
             <ul class="bg-gray-400 flex list-reset p-4 rounded-t-lg border-gray border-b-2">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -30,7 +30,7 @@ $colorByStatus = [
 
             <section class="bg-white rounded-b-lg">
                 @foreach ($projects as $project)
-                    <ul class="flex list-reset p-4 border-t border-smoke">
+                    <ul class="flex list-reset p-4 border-t border-smoke {{ $project->status === App\Project::STATUS_CURRENT ? 'bg-green-100' : 'bg-red-100' }}">
                         <li class="w-2/6">
                             <a class="text-indigo-700 hover:text-indigo-900 no-underline text-md" href="{{ $project->github_url }}">
                                 {{ $project->name }}

--- a/tests/Unit/ProjectTest.php
+++ b/tests/Unit/ProjectTest.php
@@ -4,15 +4,17 @@ namespace Tests\Unit;
 
 use App\LaravelVersion;
 use App\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ProjectTest extends TestCase
 {
+    use RefreshDatabase;
 
     /** @test */
     public function project_with_desired_version_has_current_status()
     {
-        LaravelVersion::create([
+        factory(LaravelVersion::class)->create([
             'major' => '6',
             'minor' => '3',
             'patch' => '0',
@@ -30,7 +32,7 @@ class ProjectTest extends TestCase
     /** @test */
     public function project_with_lower_version_has_behind_status()
     {
-        LaravelVersion::create([
+        factory(LaravelVersion::class)->create([
             'major' => '6',
             'minor' => '2',
             'patch' => '1',
@@ -48,7 +50,7 @@ class ProjectTest extends TestCase
     /** @test */
     public function project_with_lower_version_and_unsuported_laravel_has_insecure_status()
     {
-        LaravelVersion::create([
+        factory(LaravelVersion::class)->create([
             'major' => '5',
             'minor' => '1',
             'patch' => '20',
@@ -66,7 +68,7 @@ class ProjectTest extends TestCase
     /** @test */
     public function project_with_desired_version_has_current_status_despite_unsupported_laravel()
     {
-        LaravelVersion::create([
+        factory(LaravelVersion::class)->create([
             'major' => '5',
             'minor' => '1',
             'patch' => '20',

--- a/tests/Unit/ProjectTest.php
+++ b/tests/Unit/ProjectTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\LaravelVersion;
+use App\Project;
+use Tests\TestCase;
+
+class ProjectTest extends TestCase
+{
+
+    /** @test */
+    public function project_with_desired_version_has_current_status()
+    {
+        LaravelVersion::create([
+            'major' => '6',
+            'minor' => '3',
+            'patch' => '0',
+        ]);
+        $project = factory(Project::class)->make([
+            'current_laravel_version' => '6.3.0',
+        ]);
+
+        $status = $project->status;
+
+        $this->assertSame(Project::STATUS_CURRENT, $status);
+        $this->assertTrue($project->isCurrent());
+    }
+
+    /** @test */
+    public function project_with_lower_version_has_behind_status()
+    {
+        LaravelVersion::create([
+            'major' => '6',
+            'minor' => '2',
+            'patch' => '1',
+        ]);
+        $project = factory(Project::class)->make([
+            'current_laravel_version' => '6.1.1',
+        ]);
+
+        $status = $project->status;
+
+        $this->assertSame(Project::STATUS_BEHIND, $status);
+        $this->assertTrue($project->isBehind());
+    }
+
+    /** @test */
+    public function project_with_lower_version_and_unsuported_laravel_has_insecure_status()
+    {
+        LaravelVersion::create([
+            'major' => '5',
+            'minor' => '1',
+            'patch' => '20',
+        ]);
+        $project = factory(Project::class)->make([
+            'current_laravel_version' => '5.1.11',
+        ]);
+
+        $status = $project->status;
+
+        $this->assertSame(Project::STATUS_INSECURE, $status);
+        $this->assertTrue($project->isInsecure());
+    }
+
+    /** @test */
+    public function project_with_desired_version_has_current_status_despite_unsupported_laravel()
+    {
+        LaravelVersion::create([
+            'major' => '5',
+            'minor' => '1',
+            'patch' => '20',
+        ]);
+        $project = factory(Project::class)->make([
+            'current_laravel_version' => '5.1.20',
+        ]);
+
+        $status = $project->status;
+
+        $this->assertSame(Project::STATUS_CURRENT, $status);
+        $this->assertTrue($project->isCurrent());
+    }
+}


### PR DESCRIPTION
@mattstauffer Hi Matt! I worked on issue https://github.com/tighten/checkmate/issues/26
Despite I am convinced that is a valid solution to the issue, the PR pretends to be a bunch of questions illustrated with the code created.

I followed the idea given in https://github.com/tighten/checkmate/issues/23 of having the information stored on code. Then I created on `Project` model the method `hasSecurityFixes` which contains that information.
I like how that looked there, despite maybe the logic approach would have been to store it on a config file. What do you think?

I added a bunch of helpful methods on Project also, because I think is business logic and it is good to have it encapsulated there: `isBehind()`, `isCurrent()`, etc.
For simplicity I changed the way in which the status is presented on the blade file, adding a style also for this. I put some `static` styles on the `app.scss` file. It sounds good to you that place or do you prefer to import it ass `.css` files?
By the way, I did not push the modified content that belongs to `public`. The installation procedure covers the update of it. 

Some unit tests were added, since the number of states is bigger now and the possibilities could grow later.

Finally, after doing my changes I merged the update for grouping statuses. I fixed my changes to keep doing the group, as was solved on other issue, incorporating the new state. Let me know if this works as you expect.

Thanks for your time!

