### PR TITLE
Improve slackbot layouts for mobile devices & Fix incorrect Laravel 8 support date

### DIFF
--- a/app/LaravelVersion.php
+++ b/app/LaravelVersion.php
@@ -6,6 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class LaravelVersion extends Model
 {
+    // @see support policy https://laravel.com/docs/8.x/releases#support-policy
+    public const SECURITY_FIX_END_DATES = [
+        6 => 'September 6th, 2022',
+        7 => 'March 3rd, 2021',
+        8 => 'January 24th, 2023',
+        9 => 'January 28th, 2025',
+        10 => 'January 28th, 2025',
+    ];
+
     protected $guarded = ['id'];
 
     public function __toString()

--- a/app/Notifications/SendCheckmateStats.php
+++ b/app/Notifications/SendCheckmateStats.php
@@ -17,13 +17,13 @@ class SendCheckmateStats extends Notification
     {
         $message = (new SlackMessage)
             // Provide a text-only fallback message
-            ->content(sprintf('Here are your Checkmate stats! %s', config('app.url')))
+            ->content(sprintf('Here are your Laravel version stats for Checkmate projects! %s', config('app.url')))
             ->block(function ($block) {
                 $block
                     ->type('section')
                     ->text([
                         'type' => 'mrkdwn',
-                        'text' => 'Here are your Checkmate stats!',
+                        'text' => 'Here are your Laravel version stats for Checkmate projects! ',
                     ])
                     ->accessory([
                         'type' => 'button',
@@ -81,21 +81,17 @@ class SendCheckmateStats extends Notification
                         ->type('context')
                         ->elements([
                             [
-                                'type' => 'plain_text',
-                                'emoji' => true,
-                                'text' => $scoreMoji,
-                            ],
-                            [
                                 'type' => 'mrkdwn',
                                 'text' => sprintf(
-                                    "*Current Laravel Version:* %s",
+                                    "%s *Current:* %s",
+                                    $scoreMoji,
                                     $project->current_laravel_version,
                                 ),
                             ],
                             [
                                 'type' => 'mrkdwn',
                                 'text' => sprintf(
-                                    "*Prescribed Version:* %s",
+                                    "*Prescribed:* %s",
                                     $project->desiredLaravelVersion,
                                 ),
                             ],

--- a/app/Notifications/SendCheckmateStats.php
+++ b/app/Notifications/SendCheckmateStats.php
@@ -88,8 +88,14 @@ class SendCheckmateStats extends Notification
                             [
                                 'type' => 'mrkdwn',
                                 'text' => sprintf(
-                                    "Current Version: %s\t\t\tPrescribed Version Status: %s",
+                                    "*Current Laravel Version:* %s",
                                     $project->current_laravel_version,
+                                ),
+                            ],
+                            [
+                                'type' => 'mrkdwn',
+                                'text' => sprintf(
+                                    "*Prescribed Version:* %s",
                                     $project->desiredLaravelVersion,
                                 ),
                             ],

--- a/app/Project.php
+++ b/app/Project.php
@@ -83,7 +83,6 @@ class Project extends Model
         $major = explode('.', $this->current_laravel_version)[0];
 
         return isset(self::SECURITY_FIX_END_DATES[$major]) && strtotime(self::SECURITY_FIX_END_DATES[$major]) >= strtotime('today');
-
     }
 
     public function scopeActive($query)

--- a/app/Project.php
+++ b/app/Project.php
@@ -11,6 +11,15 @@ class Project extends Model
     public const STATUS_CURRENT = 'current';
     public const STATUS_INSECURE = 'insecure';
 
+    // @see support policy https://laravel.com/docs/8.x/releases#support-policy
+    public const SECURITY_FIX_END_DATES = [
+        6 => 'September 6th, 2022',
+        7 => 'March 3rd, 2021',
+        8 => 'January 24th, 2023',
+        9 => 'January 28th, 2025',
+        10 => 'January 28th, 2025',
+    ];
+
     protected $guarded = ['id'];
 
     protected $casts = [
@@ -73,19 +82,27 @@ class Project extends Model
     {
         $major = explode('.', $this->current_laravel_version)[0];
 
+        if ($major === '10') {
+            return strtotime(self::SECURITY_FIX_END_DATES[10]) >= strtotime('today');
+        }
+
+        if ($major === '9') {
+            return strtotime(self::SECURITY_FIX_END_DATES[9]) >= strtotime('today');
+        }
+
         if ($major === '8') {
             // @see https://laravel.com/docs/8.x/releases#support-policy
-            return strtotime('September 8th, 2021') >= strtotime('today');
+            return strtotime(self::SECURITY_FIX_END_DATES[8]) >= strtotime('today');
         }
 
         if ($major === '7') {
             // @see https://laravel.com/docs/7.x/releases#support-policy
-            return strtotime('March 3rd, 2021') >= strtotime('today');
+            return strtotime(self::SECURITY_FIX_END_DATES[7]) >= strtotime('today');
         }
 
         if ($major === '6') {
             // @see https://laravel.com/docs/6.x/releases#support-policy
-            return strtotime('September 3rd, 2022') >= strtotime('today');
+            return strtotime(self::SECURITY_FIX_END_DATES[6]) >= strtotime('today');
         }
 
         return false;

--- a/app/Project.php
+++ b/app/Project.php
@@ -82,30 +82,8 @@ class Project extends Model
     {
         $major = explode('.', $this->current_laravel_version)[0];
 
-        if ($major === '10') {
-            return strtotime(self::SECURITY_FIX_END_DATES[10]) >= strtotime('today');
-        }
+        return isset(self::SECURITY_FIX_END_DATES[$major]) && strtotime(self::SECURITY_FIX_END_DATES[$major]) >= strtotime('today');
 
-        if ($major === '9') {
-            return strtotime(self::SECURITY_FIX_END_DATES[9]) >= strtotime('today');
-        }
-
-        if ($major === '8') {
-            // @see https://laravel.com/docs/8.x/releases#support-policy
-            return strtotime(self::SECURITY_FIX_END_DATES[8]) >= strtotime('today');
-        }
-
-        if ($major === '7') {
-            // @see https://laravel.com/docs/7.x/releases#support-policy
-            return strtotime(self::SECURITY_FIX_END_DATES[7]) >= strtotime('today');
-        }
-
-        if ($major === '6') {
-            // @see https://laravel.com/docs/6.x/releases#support-policy
-            return strtotime(self::SECURITY_FIX_END_DATES[6]) >= strtotime('today');
-        }
-
-        return false;
     }
 
     public function scopeActive($query)

--- a/app/Project.php
+++ b/app/Project.php
@@ -11,15 +11,6 @@ class Project extends Model
     public const STATUS_CURRENT = 'current';
     public const STATUS_INSECURE = 'insecure';
 
-    // @see support policy https://laravel.com/docs/8.x/releases#support-policy
-    public const SECURITY_FIX_END_DATES = [
-        6 => 'September 6th, 2022',
-        7 => 'March 3rd, 2021',
-        8 => 'January 24th, 2023',
-        9 => 'January 28th, 2025',
-        10 => 'January 28th, 2025',
-    ];
-
     protected $guarded = ['id'];
 
     protected $casts = [
@@ -82,7 +73,7 @@ class Project extends Model
     {
         $major = explode('.', $this->current_laravel_version)[0];
 
-        return isset(self::SECURITY_FIX_END_DATES[$major]) && strtotime(self::SECURITY_FIX_END_DATES[$major]) >= strtotime('today');
+        return isset(LaravelVersion::SECURITY_FIX_END_DATES[$major]) && strtotime(LaravelVersion::SECURITY_FIX_END_DATES[$major]) >= strtotime('today');
     }
 
     public function scopeActive($query)


### PR DESCRIPTION
* Fixes Security end date for Laravel 8 (We had `September 8, 2021` but the correct date is `January 24th, 2023`). This was causing incorrect statuses for projects with Laravel 8. https://laravel.com/docs/8.x/releases#support-policy
* Adds support for Laravel 9 and 10
* In the slackbot, splits the text block into into individual markdown blocks for improved layout on mobile devices.
* Adds clarifying `Laravel` to the text displayed