### PR TITLE
Pad column headers

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -23,19 +23,19 @@ $backgroundColorByStatus = [
         </p>
         <div class="rounded-lg shadow">
             <ul class="flex p-4 bg-gray-400 border-b-2 rounded-t-lg list-reset border-gray">
-                <li class="w-2/6 text-xs font-semibold tracking-wide uppercase">Project / Package name</li>
+                <li class="w-2/6 text-xs font-semibold tracking-wide uppercase px-2">Project / Package name</li>
 
-                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase">Version Constraint</li>
+                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase px-2">Version Constraint</li>
 
-                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase">Current Version</li>
+                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase px-2">Current Version</li>
 
-                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase">Prescribed Version</li>
+                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase px-2">Prescribed Version</li>
 
-                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase">Status</li>
+                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase px-2">Status</li>
 
-                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase">Ignore</li>
+                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase px-2">Ignore</li>
 
-                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase">Private?</li>
+                <li class="w-1/6 text-xs font-semibold tracking-wide uppercase px-2">Private?</li>
             </ul>
 
             <section class="bg-white rounded-b-lg">


### PR DESCRIPTION
Adds a bit of horizontal padding to column headers.

**Before:**
<img width="1170" alt="Screen Shot 2021-09-17 at 9 33 50 AM" src="https://user-images.githubusercontent.com/4378273/133791276-56a46c76-33a0-463a-a0c6-74dc299e944f.png">
**After:**
<img width="1155" alt="Screen Shot 2021-09-17 at 9 33 31 AM" src="https://user-images.githubusercontent.com/4378273/133791273-a424d9cb-75c3-449c-9f4a-8a277ee0842d.png">
