### PR TITLE
Prevent error on missing GitHub pageInfo response

### DIFF
--- a/app/Actions/GetProjectsFromGitHub.php
+++ b/app/Actions/GetProjectsFromGitHub.php
@@ -143,7 +143,7 @@ class GetProjectsFromGitHub
 
     protected function handleNextPage($response): ?string
     {
-        $nextPage = data_get($response, 'data.organization.repositories.pageInfo')['endCursor'];
+        $nextPage = data_get($response, 'data.organization.repositories.pageInfo')['endCursor'] ?? null;
 
         if ($nextPage) {
             $this->info('Getting another page.');


### PR DESCRIPTION
This PR checks for missing `pageInfo` attributes from Github's api. This should be an extremely uncommon occurrence, but has happened in production, so this check will prevent the `sync:projects` command from failing if it happens again.